### PR TITLE
fixup the `if` check on the db status

### DIFF
--- a/ops/bin/deploy
+++ b/ops/bin/deploy
@@ -18,9 +18,10 @@ function provision {
 
   docker ps -a | grep collision-db > /dev/null
   DB_ALREADY_DEPLOYED=$?
-  if [ $DB_ALREADY_DEPLOYED ]
+  if [ $DB_ALREADY_DEPLOYED -eq 0 ]
   then
     echo "Database previously deployed."
+    docker start collision-db
   else
     echo "Deploying new database container."
     docker run --name collision-db -d mdillon/postgis


### PR DESCRIPTION
Additionally, if the database has already been 'run' then use `docker
start` to bring the container back up as it has been configured: daemon
mode, port bindings etc.